### PR TITLE
Implement perfil page

### DIFF
--- a/src/app/components/side-menu/side-menu.component.ts
+++ b/src/app/components/side-menu/side-menu.component.ts
@@ -37,7 +37,8 @@ import {
 export class SideMenuComponent {
   menuItems = [
     { title: 'Inicio', icon: 'home', path: '/home' },
-    { title: 'Perfil', icon: 'person', path: '/profile' },
+    // Ruta correcta para el perfil
+    { title: 'Perfil', icon: 'person', path: '/perfil' },
     { title: 'Configuración', icon: 'settings', path: '/settings' }
   ];
 

--- a/src/app/perfil/perfil.page.html
+++ b/src/app/perfil/perfil.page.html
@@ -1,13 +1,52 @@
-<ion-header [translucent]="true">
-  <ion-toolbar>
-    <ion-title>perfil</ion-title>
+<ion-header>
+  <ion-toolbar color="primary">
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/home"></ion-back-button>
+    </ion-buttons>
+    <ion-title>Mi Perfil</ion-title>
+    <ion-buttons slot="end">
+      <ion-button *ngIf="!isEditing" (click)="toggleEdit()">
+        <ion-icon name="create-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 
-<ion-content [fullscreen]="true">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">perfil</ion-title>
-    </ion-toolbar>
-  </ion-header>
+<ion-content class="ion-padding">
+  <form [formGroup]="profileForm">
+    <ion-item>
+      <ion-label position="stacked">Nombres</ion-label>
+      <ion-input formControlName="name" [readonly]="!isEditing"></ion-input>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">Apellidos</ion-label>
+      <ion-input formControlName="lastname" [readonly]="!isEditing"></ion-input>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">Correo electrónico</ion-label>
+      <ion-input formControlName="email" [readonly]="!isEditing"></ion-input>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">Teléfono</ion-label>
+      <ion-input formControlName="phone" [readonly]="!isEditing"></ion-input>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">Dirección</ion-label>
+      <ion-input formControlName="address" [readonly]="!isEditing"></ion-input>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">Usuario</ion-label>
+      <ion-input formControlName="username" [readonly]="!isEditing"></ion-input>
+    </ion-item>
+
+    <div class="button-group" *ngIf="isEditing">
+      <ion-button expand="block" color="primary" (click)="saveProfile()">Guardar</ion-button>
+      <ion-button expand="block" fill="outline" color="medium" (click)="toggleEdit()">Cancelar</ion-button>
+    </div>
+  </form>
 </ion-content>

--- a/src/app/perfil/perfil.page.scss
+++ b/src/app/perfil/perfil.page.scss
@@ -1,0 +1,6 @@
+.button-group {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/src/app/perfil/perfil.page.ts
+++ b/src/app/perfil/perfil.page.ts
@@ -1,20 +1,102 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { IonicModule, AlertController, LoadingController, IonBackButton } from '@ionic/angular';
+import { PerfilService } from '../services/perfil.service';
 
 @Component({
   selector: 'app-perfil',
   templateUrl: './perfil.page.html',
   styleUrls: ['./perfil.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule]
+  imports: [CommonModule, IonicModule, FormsModule, ReactiveFormsModule, IonBackButton],
+  providers: [PerfilService]
 })
 export class PerfilPage implements OnInit {
+  profileForm!: FormGroup;
+  isEditing = false;
 
-  constructor() { }
+  constructor(
+    private fb: FormBuilder,
+    private perfilService: PerfilService,
+    private alertCtrl: AlertController,
+    private loadingCtrl: LoadingController
+  ) {}
 
   ngOnInit() {
+    this.initForm();
+    this.loadProfile();
   }
 
+  private initForm() {
+    this.profileForm = this.fb.group({
+      name: ['', Validators.required],
+      lastname: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
+      phone: [''],
+      address: [''],
+      username: ['', Validators.required]
+    });
+  }
+
+  private loadProfile() {
+    // Obtener datos almacenados localmente
+    const stored = localStorage.getItem('user_data');
+    if (stored) {
+      const data = JSON.parse(stored);
+      this.profileForm.patchValue({
+        name: data.name || '',
+        lastname: data.lastname || '',
+        email: data.email || '',
+        phone: data.phone || '',
+        address: data.address || '',
+        username: data.username || ''
+      });
+    }
+
+    // Si se requiere cargar datos desde el backend, descomentar lo siguiente
+    // this.perfilService.getProfile().subscribe(resp => this.profileForm.patchValue(resp));
+  }
+
+  toggleEdit() {
+    this.isEditing = !this.isEditing;
+    if (!this.isEditing) {
+      this.loadProfile();
+    }
+  }
+
+  async saveProfile() {
+    if (this.profileForm.invalid) {
+      const alert = await this.alertCtrl.create({
+        header: 'Datos inválidos',
+        message: 'Revisa los campos marcados',
+        buttons: ['OK']
+      });
+      await alert.present();
+      return;
+    }
+
+    const loading = await this.loadingCtrl.create({
+      message: 'Guardando...',
+      spinner: 'crescent'
+    });
+    await loading.present();
+
+    const data = this.profileForm.value;
+
+    // Enviar los datos al backend cuando el endpoint esté disponible
+    // this.perfilService.updateProfile(data).subscribe({
+    //   next: () => {
+    //     loading.dismiss();
+    //     this.isEditing = false;
+    //   },
+    //   error: () => {
+    //     loading.dismiss();
+    //   }
+    // });
+
+    console.log('Datos de perfil a guardar', data);
+    loading.dismiss();
+    this.isEditing = false;
+  }
 }

--- a/src/app/services/perfil.service.ts
+++ b/src/app/services/perfil.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PerfilService {
+  // Base URL del API
+  private apiUrl = 'http://34.10.172.54:8080';
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Obtiene la información del perfil del usuario autenticado.
+   * Reemplazar '/users/me' con el endpoint real.
+   */
+  getProfile(): Observable<any> {
+    // TODO: actualizar el endpoint real del perfil
+    return this.http.get(`${this.apiUrl}/users/me`);
+  }
+
+  /**
+   * Envía los datos modificados del perfil al backend.
+   * Reemplazar '/users/me' con el endpoint real para actualizar.
+   */
+  updateProfile(data: any): Observable<any> {
+    // TODO: actualizar el endpoint real para guardar cambios
+    return this.http.put(`${this.apiUrl}/users/me`, data);
+  }
+}


### PR DESCRIPTION
## Summary
- update side menu route for profile
- implement a profile service with placeholder endpoints
- build profile page with edit/save logic

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68858a91d634832a92ea91af5df8699f