### PR TITLE
feat: enhance registration file upload ui

### DIFF
--- a/src/app/registro-app/registro-app.page.html
+++ b/src/app/registro-app/registro-app.page.html
@@ -139,31 +139,50 @@
           </div>
         </div>
 
-        <!-- Fila 5: Archivos -->
-        <div class="form-row">
-          <div class="form-field-wrapper">
-            <ion-item class="form-field" lines="full">
-              <ion-label position="stacked">Documento de Identidad <span class="required">*</span></ion-label>
-              <input type="file" (change)="onFileChange($event, 'identityDocument')" />
-            </ion-item>
+          <!-- Fila 5: Archivos -->
+          <div class="form-row">
+            <div class="form-field-wrapper">
+              <label class="upload-label">Documento de Identidad <span class="required">*</span></label>
+              <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onDrop($event, 'identityDocument')">
+                <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+                <p>Arrastra tus imágenes aquí o haz clic para seleccionar archivos</p>
+                <input type="file" accept=".jpg,.jpeg,.png" (change)="onFileChange($event, 'identityDocument')" />
+              </div>
+              <div class="upload-info">
+                <div><ion-icon name="images-outline"></ion-icon><span>JPG, JPEG, PNG</span></div>
+                <div><ion-icon name="cloud-upload-outline"></ion-icon><span>2 MB por archivo</span></div>
+                <div><ion-icon name="resize-outline"></ion-icon><span>Mínimo 800x600 px</span></div>
+              </div>
+            </div>
+
+            <div class="form-field-wrapper">
+              <label class="upload-label">Patente Municipal <span class="required">*</span></label>
+              <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onDrop($event, 'certificate')">
+                <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+                <p>Arrastra tus imágenes aquí o haz clic para seleccionar archivos</p>
+                <input type="file" accept=".jpg,.jpeg,.png" (change)="onFileChange($event, 'certificate')" />
+              </div>
+              <div class="upload-info">
+                <div><ion-icon name="images-outline"></ion-icon><span>JPG, JPEG, PNG</span></div>
+                <div><ion-icon name="cloud-upload-outline"></ion-icon><span>2 MB por archivo</span></div>
+                <div><ion-icon name="resize-outline"></ion-icon><span>Mínimo 800x600 px</span></div>
+              </div>
+            </div>
           </div>
 
           <div class="form-field-wrapper">
-            <ion-item class="form-field" lines="full">
-              <ion-label position="stacked">Patente Municipal <span class="required">*</span></ion-label>
-              <input type="file" (change)="onFileChange($event, 'certificate')" />
-            </ion-item>
+            <label class="upload-label">Acuerdo de Comercializacion <span class="required">*</span></label>
+            <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onDrop($event, 'signedDocument')">
+              <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+              <p>Arrastra tus imágenes aquí o haz clic para seleccionar archivos</p>
+              <input type="file" accept=".jpg,.jpeg,.png" (change)="onFileChange($event, 'signedDocument')" />
+            </div>
+            <div class="upload-info">
+              <div><ion-icon name="images-outline"></ion-icon><span>JPG, JPEG, PNG</span></div>
+              <div><ion-icon name="cloud-upload-outline"></ion-icon><span>2 MB por archivo</span></div>
+              <div><ion-icon name="resize-outline"></ion-icon><span>Mínimo 800x600 px</span></div>
+            </div>
           </div>
-        </div>
-
-
-       
-        <div class="form-field-wrapper">
-  <ion-item class="form-field" lines="full">
-    <ion-label position="stacked">Acuerdo de Comercializacion <span class="required">*</span></ion-label>
-    <input type="file" (change)="onFileChange($event, 'signedDocument')" />
-  </ion-item>
-</div>
 
 
       </div>

--- a/src/app/registro-app/registro-app.page.scss
+++ b/src/app/registro-app/registro-app.page.scss
@@ -122,6 +122,63 @@
   display: block;
 }
 
+.file-hint {
+  color: #6b7280;
+  font-size: 12px;
+  margin: 4px 0 8px 16px;
+  display: block;
+}
+
+// Upload box styles
+.upload-label {
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 4px;
+}
+
+.upload-box {
+  border: 2px dashed #d1d5db;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: center;
+  background-color: #f9fafb;
+  position: relative;
+  cursor: pointer;
+
+  .upload-icon {
+    font-size: 48px;
+    color: #fbbf24;
+    margin-bottom: 8px;
+  }
+
+  input[type='file'] {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+  }
+}
+
+.upload-info {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  font-size: 12px;
+  color: #6b7280;
+
+  div {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  ion-icon {
+    font-size: 16px;
+  }
+}
+
 // Button container
 .button-container {
   margin-top: 30px;

--- a/src/app/registro-app/registro-app.page.ts
+++ b/src/app/registro-app/registro-app.page.ts
@@ -84,7 +84,11 @@ signedDocumentFile!: File;
   }
   async onSubmit() {
     const isValid = await this.validateForm();
-    if (!isValid || !this.identityDocumentFile || !this.certificateFile) {
+    if (!isValid) {
+      return;
+    }
+    if (!this.identityDocumentFile || !this.certificateFile || !this.signedDocumentFile) {
+      await this.showToast('Debe adjuntar todos los documentos requeridos', 'warning');
       return;
     }
 
@@ -201,18 +205,46 @@ signedDocumentFile!: File;
     return labels[fieldName] || fieldName;
   }
 
-  onFileChange(event: Event, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
+  async onFileChange(event: any, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
     const input = event.target as HTMLInputElement;
-    if (input.files && input.files.length > 0) {
-      const file = input.files[0];
+    const files = input.files || event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      const file = files[0];
+      const allowedExtensions = ['jpg', 'jpeg', 'png'];
+      const extension = file.name.split('.').pop()?.toLowerCase();
+
+      if (!extension || !allowedExtensions.includes(extension)) {
+        await this.showToast('Formato de archivo no permitido. Solo JPG, JPEG o PNG', 'warning');
+        if (input) { input.value = ''; }
+        return;
+      }
+
+      const maxSize = 2 * 1024 * 1024;
+      if (file.size > maxSize) {
+        await this.showToast('El archivo supera el tamaño máximo de 2 MB', 'warning');
+        if (input) { input.value = ''; }
+        return;
+      }
+
       if (tipo === 'identityDocument') {
         this.identityDocumentFile = file;
       } else if (tipo === 'certificate') {
         this.certificateFile = file;
-        } else if (tipo === 'signedDocument') { 
-      this.signedDocumentFile = file;
+      } else if (tipo === 'signedDocument') {
+        this.signedDocumentFile = file;
       }
+
+      await this.showToast('Archivo cargado correctamente', 'success');
     }
+  }
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  onDrop(event: DragEvent, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
+    event.preventDefault();
+    this.onFileChange(event, tipo);
   }
 
   hasError(fieldName: string): boolean {


### PR DESCRIPTION
## Summary
- implement drag-and-drop upload boxes with format, size and resolution hints for registration documents
- validate JPG/JPEG/PNG uploads with a 2MB limit and drag-and-drop support

## Testing
- `npm run lint` *(fails: Lifecycle methods should not be empty; Prefer using the inject() function over constructor parameter injection)*
- `npm test -- --watch=false` *(fails: export 'RegistrooService' not found; Can't resolve 'node_modules/ionicons/css/ionicons.min.css')*

------
https://chatgpt.com/codex/tasks/task_e_688ebecc3018832a88a5d3735b4946f0