### PR TITLE
feat: enhance registration file upload ui

### DIFF
--- a/src/app/registro-app/registro-app.page.html
+++ b/src/app/registro-app/registro-app.page.html
@@ -139,31 +139,62 @@
           </div>
         </div>
 
-        <!-- Fila 5: Archivos -->
-        <div class="form-row">
-          <div class="form-field-wrapper">
-            <ion-item class="form-field" lines="full">
-              <ion-label position="stacked">Documento de Identidad <span class="required">*</span></ion-label>
-              <input type="file" (change)="onFileChange($event, 'identityDocument')" />
-            </ion-item>
+          <!-- Fila 5: Archivos -->
+          <div class="form-row">
+                <div class="form-field-wrapper">
+                  <label id="identityDocumentLabel" class="upload-label" for="identityDocumentInput">Documento de Identidad <span class="required">*</span></label>
+                  <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onDrop($event, 'identityDocument')">
+                      <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+                    <p>Arrastra tus archivos aquí o haz clic para seleccionar archivos</p>
+                    <input id="identityDocumentInput" type="file" accept=".pdf,.jpg,.jpeg,.png" title="Documento de identidad (PDF, JPG o PNG, máx. 2 MB)" aria-labelledby="identityDocumentLabel identityDocumentHelp" aria-describedby="identityDocumentHelp" (change)="onFileChange($event, 'identityDocument')" />
+                  </div>
+                  <div class="file-name" *ngIf="identityDocumentFile">
+                      <ion-icon name="document-outline"></ion-icon>
+                    <span>{{ identityDocumentFile.name }}</span>
+                  </div>
+                  <div class="upload-info" id="identityDocumentHelp">
+                      <div><ion-icon name="document-text-outline"></ion-icon><span>PDF, JPG, PNG</span></div>
+                      <div><ion-icon name="cloud-upload-outline"></ion-icon><span>2 MB por archivo</span></div>
+                      <div><ion-icon name="resize-outline"></ion-icon><span>Mínimo 800x600 px</span></div>
+                  </div>
+                </div>
+
+                <div class="form-field-wrapper">
+                  <label id="certificateLabel" class="upload-label" for="certificateInput">Patente Municipal <span class="required">*</span></label>
+                  <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onDrop($event, 'certificate')">
+                    <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+                    <p>Arrastra tus archivos aquí o haz clic para seleccionar archivos</p>
+                    <input id="certificateInput" type="file" accept=".pdf,.jpg,.jpeg,.png" title="Patente municipal (PDF, JPG o PNG, máx. 2 MB)" aria-labelledby="certificateLabel certificateHelp" aria-describedby="certificateHelp" (change)="onFileChange($event, 'certificate')" />
+                  </div>
+                    <div class="file-name" *ngIf="certificateFile">
+                      <ion-icon name="document-outline"></ion-icon>
+                      <span>{{ certificateFile.name }}</span>
+                    </div>
+                    <div class="upload-info" id="certificateHelp">
+                      <div><ion-icon name="document-text-outline"></ion-icon><span>PDF, JPG, PNG</span></div>
+                      <div><ion-icon name="cloud-upload-outline"></ion-icon><span>2 MB por archivo</span></div>
+                      <div><ion-icon name="resize-outline"></ion-icon><span>Mínimo 800x600 px</span></div>
+                    </div>
+                </div>
           </div>
 
-          <div class="form-field-wrapper">
-            <ion-item class="form-field" lines="full">
-              <ion-label position="stacked">Patente Municipal <span class="required">*</span></ion-label>
-              <input type="file" (change)="onFileChange($event, 'certificate')" />
-            </ion-item>
-          </div>
-        </div>
-
-
-       
-        <div class="form-field-wrapper">
-  <ion-item class="form-field" lines="full">
-    <ion-label position="stacked">Acuerdo de Comercializacion <span class="required">*</span></ion-label>
-    <input type="file" (change)="onFileChange($event, 'signedDocument')" />
-  </ion-item>
-</div>
+              <div class="form-field-wrapper">
+                <label id="signedDocumentLabel" class="upload-label" for="signedDocumentInput">Acuerdo de Comercializacion <span class="required">*</span></label>
+                <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onDrop($event, 'signedDocument')">
+                  <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+                  <p>Arrastra tus archivos aquí o haz clic para seleccionar archivos</p>
+                  <input id="signedDocumentInput" type="file" accept=".pdf,.jpg,.jpeg,.png" title="Acuerdo de comercialización (PDF, JPG o PNG, máx. 2 MB)" aria-labelledby="signedDocumentLabel signedDocumentHelp" aria-describedby="signedDocumentHelp" (change)="onFileChange($event, 'signedDocument')" />
+                </div>
+                <div class="file-name" *ngIf="signedDocumentFile">
+                  <ion-icon name="document-outline"></ion-icon>
+                  <span>{{ signedDocumentFile.name }}</span>
+                </div>
+                <div class="upload-info" id="signedDocumentHelp">
+                  <div><ion-icon name="document-text-outline"></ion-icon><span>PDF, JPG, PNG</span></div>
+                  <div><ion-icon name="cloud-upload-outline"></ion-icon><span>2 MB por archivo</span></div>
+                  <div><ion-icon name="resize-outline"></ion-icon><span>Mínimo 800x600 px</span></div>
+                </div>
+              </div>
 
 
       </div>

--- a/src/app/registro-app/registro-app.page.scss
+++ b/src/app/registro-app/registro-app.page.scss
@@ -122,6 +122,78 @@
   display: block;
 }
 
+.file-hint {
+  color: #6b7280;
+  font-size: 12px;
+  margin: 4px 0 8px 16px;
+  display: block;
+}
+
+// Upload box styles
+.upload-label {
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 4px;
+}
+
+.upload-box {
+  border: 2px dashed #d1d5db;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: center;
+  background-color: #f9fafb;
+  position: relative;
+  cursor: pointer;
+
+  .upload-icon {
+    font-size: 48px;
+    color: #fbbf24;
+    margin-bottom: 8px;
+  }
+
+  input[type='file'] {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+  }
+}
+
+.upload-info {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  font-size: 12px;
+  color: #6b7280;
+
+  div {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  ion-icon {
+    font-size: 16px;
+  }
+}
+
+.file-name {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 8px;
+  font-size: 13px;
+  color: #374151;
+
+  ion-icon {
+    font-size: 16px;
+    margin-right: 4px;
+    color: #6b7280;
+  }
+}
+
 // Button container
 .button-container {
   margin-top: 30px;

--- a/src/app/registro-app/registro-app.page.ts
+++ b/src/app/registro-app/registro-app.page.ts
@@ -84,7 +84,12 @@ signedDocumentFile!: File;
   }
   async onSubmit() {
     const isValid = await this.validateForm();
-    if (!isValid || !this.identityDocumentFile || !this.certificateFile) {
+    if (!isValid) {
+      return;
+    }
+
+    const filesValid = await this.validateFiles();
+    if (!filesValid) {
       return;
     }
 
@@ -111,7 +116,9 @@ signedDocumentFile!: File;
       error: async (err: HttpErrorResponse) => {
         this.isLoading = false;
         let message = 'Error en el servidor';
-        if (err.error?.message) {
+        if (err.status === 413 || err.error?.message?.includes('tamaño máximo')) {
+          message = 'El archivo supera el tamaño máximo permitido de 2 MB';
+        } else if (err.error?.message) {
           message = err.error.message;
         }
         await this.showToast(message, 'danger');
@@ -201,22 +208,93 @@ signedDocumentFile!: File;
     return labels[fieldName] || fieldName;
   }
 
-  onFileChange(event: Event, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
+  async onFileChange(event: any, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
     const input = event.target as HTMLInputElement;
-    if (input.files && input.files.length > 0) {
-      const file = input.files[0];
+    const files = input.files || event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      const file = files[0];
+      const allowedExtensions = ['pdf', 'jpg', 'jpeg', 'png'];
+      const extension = file.name.split('.').pop()?.toLowerCase();
+
+      if (!extension || !allowedExtensions.includes(extension)) {
+        await this.showToast('Formato de archivo no permitido. Solo PDF, JPG o PNG', 'warning');
+        if (input) { input.value = ''; }
+        this.clearFile(tipo);
+        return;
+      }
+
+      const maxSize = 2 * 1024 * 1024;
+      if (file.size > maxSize) {
+        await this.showToast('El archivo supera el tamaño máximo de 2 MB', 'warning');
+        if (input) { input.value = ''; }
+        this.clearFile(tipo);
+        return;
+      }
+
       if (tipo === 'identityDocument') {
         this.identityDocumentFile = file;
       } else if (tipo === 'certificate') {
         this.certificateFile = file;
-        } else if (tipo === 'signedDocument') { 
-      this.signedDocumentFile = file;
+      } else if (tipo === 'signedDocument') {
+        this.signedDocumentFile = file;
       }
+
+      await this.showToast('Archivo cargado correctamente', 'success');
     }
+  }
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  onDrop(event: DragEvent, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
+    event.preventDefault();
+    this.onFileChange(event, tipo);
   }
 
   hasError(fieldName: string): boolean {
     const field = this.registroForm.get(fieldName);
     return !!(field?.errors && field.touched);
+  }
+
+  private async validateFiles(): Promise<boolean> {
+    const maxSize = 2 * 1024 * 1024;
+    const allowedExtensions = ['pdf', 'jpg', 'jpeg', 'png'];
+
+    const files = [
+      { file: this.identityDocumentFile, name: 'Documento de Identidad' },
+      { file: this.certificateFile, name: 'Patente Municipal' },
+      { file: this.signedDocumentFile, name: 'Acuerdo de Comercialización' }
+    ];
+
+    for (const item of files) {
+      if (!item.file) {
+        await this.showToast('Debe adjuntar todos los documentos requeridos', 'warning');
+        return false;
+      }
+
+      const extension = item.file.name.split('.').pop()?.toLowerCase();
+      if (!extension || !allowedExtensions.includes(extension)) {
+        await this.showToast(`Formato de archivo no permitido en ${item.name}. Solo PDF, JPG o PNG`, 'warning');
+        return false;
+      }
+
+      if (item.file.size > maxSize) {
+        await this.showToast(`El archivo ${item.name} supera el tamaño máximo de 2 MB`, 'warning');
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private clearFile(tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
+    if (tipo === 'identityDocument') {
+      this.identityDocumentFile = undefined as any;
+    } else if (tipo === 'certificate') {
+      this.certificateFile = undefined as any;
+    } else {
+      this.signedDocumentFile = undefined as any;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- show selected file names and accept PDF/JPG/PNG with 2MB limit in registration uploads
- style file name row for each upload box
- label file inputs with titles and guard against oversize files

## Testing
- `npm test -- --watch=false` *(fails: export 'RegistrooService' not found; Can't resolve 'node_modules/ionicons/css/ionicons.min.css')*
- `npm run lint` *(fails: Lifecycle methods should not be empty; Prefer using the inject() function over constructor parameter injection)*

------
https://chatgpt.com/codex/tasks/task_e_688ebecc3018832a88a5d3735b4946f0