### PR TITLE
Improve registration document upload validations and UI

### DIFF
--- a/src/app/registro-app/registro-app.page.html
+++ b/src/app/registro-app/registro-app.page.html
@@ -142,32 +142,71 @@
         <!-- Fila 5: Archivos -->
         <div class="form-row">
           <div class="form-field-wrapper">
-            <ion-item class="form-field" lines="full">
-              <ion-label position="stacked">Documento de Identidad <span class="required">*</span></ion-label>
-              <input type="file" (change)="onFileChange($event, 'identityDocument')" />
-            </ion-item>
+            <label class="file-label">Documento de Identidad <span class="required">*</span></label>
+            <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onFileDrop($event, 'identityDocument')" (click)="identityInput.click()">
+              <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+              <p *ngIf="!identityDocumentFile">Arrastra tu archivo aquí o haz clic para seleccionar</p>
+              <p *ngIf="identityDocumentFile">{{ identityDocumentFile.name }}</p>
+              <input type="file" #identityInput hidden accept=".pdf,.jpg,.jpeg,.png" (change)="onFileChange($event, 'identityDocument')" />
+            </div>
+            <div class="upload-info">
+              <ion-icon name="document-text-outline"></ion-icon>
+              <span>Formatos permitidos: PDF, JPG, PNG</span>
+            </div>
+            <div class="upload-info">
+              <ion-icon name="resize-outline"></ion-icon>
+              <span>Tamaño máximo: 2 MB por archivo</span>
+            </div>
+            <div class="upload-info">
+              <ion-icon name="image-outline"></ion-icon>
+              <span>Resolución recomendada: mínimo 800x600 px</span>
+            </div>
           </div>
 
           <div class="form-field-wrapper">
-            <ion-item class="form-field" lines="full">
-              <ion-label position="stacked">Patente Municipal <span class="required">*</span></ion-label>
-              <input type="file" (change)="onFileChange($event, 'certificate')" />
-            </ion-item>
+            <label class="file-label">Patente Municipal <span class="required">*</span></label>
+            <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onFileDrop($event, 'certificate')" (click)="certificateInput.click()">
+              <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+              <p *ngIf="!certificateFile">Arrastra tu archivo aquí o haz clic para seleccionar</p>
+              <p *ngIf="certificateFile">{{ certificateFile.name }}</p>
+              <input type="file" #certificateInput hidden accept=".pdf,.jpg,.jpeg,.png" (change)="onFileChange($event, 'certificate')" />
+            </div>
+            <div class="upload-info">
+              <ion-icon name="document-text-outline"></ion-icon>
+              <span>Formatos permitidos: PDF, JPG, PNG</span>
+            </div>
+            <div class="upload-info">
+              <ion-icon name="resize-outline"></ion-icon>
+              <span>Tamaño máximo: 2 MB por archivo</span>
+            </div>
+            <div class="upload-info">
+              <ion-icon name="image-outline"></ion-icon>
+              <span>Resolución recomendada: mínimo 800x600 px</span>
+            </div>
           </div>
         </div>
 
-
-       
         <div class="form-field-wrapper">
-  <ion-item class="form-field" lines="full">
-    <ion-label position="stacked">Acuerdo de Comercializacion <span class="required">*</span></ion-label>
-    <input type="file" (change)="onFileChange($event, 'signedDocument')" />
-  </ion-item>
-</div>
-
-
-      </div>
-
+          <label class="file-label">Acuerdo de Comercializacion <span class="required">*</span></label>
+          <div class="upload-box" (dragover)="onDragOver($event)" (drop)="onFileDrop($event, 'signedDocument')" (click)="signedInput.click()">
+            <ion-icon name="folder-open" class="upload-icon"></ion-icon>
+            <p *ngIf="!signedDocumentFile">Arrastra tu archivo aquí o haz clic para seleccionar</p>
+            <p *ngIf="signedDocumentFile">{{ signedDocumentFile.name }}</p>
+            <input type="file" #signedInput hidden accept=".pdf,.jpg,.jpeg,.png" (change)="onFileChange($event, 'signedDocument')" />
+          </div>
+          <div class="upload-info">
+            <ion-icon name="document-text-outline"></ion-icon>
+            <span>Formatos permitidos: PDF, JPG, PNG</span>
+          </div>
+          <div class="upload-info">
+            <ion-icon name="resize-outline"></ion-icon>
+            <span>Tamaño máximo: 2 MB por archivo</span>
+          </div>
+          <div class="upload-info">
+            <ion-icon name="image-outline"></ion-icon>
+            <span>Resolución recomendada: mínimo 800x600 px</span>
+          </div>
+        </div>
       <!-- Botones -->
       <div class="button-container">
         <ion-button expand="block" color="danger" type="submit" [disabled]="!registroForm.valid || isLoading"

--- a/src/app/registro-app/registro-app.page.scss
+++ b/src/app/registro-app/registro-app.page.scss
@@ -241,8 +241,50 @@ ion-item {
 ion-button[fill="clear"] {
   --color: #6b7280;
   margin: 0;
-  
+
   &:hover {
     --color: #dc2626;
+  }
+}
+
+// File upload styles
+.file-label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+  color: #374151;
+}
+
+.upload-box {
+  border: 2px dashed #d1d5db;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: center;
+  cursor: pointer;
+  background: #f9fafb;
+  transition: background 0.3s ease;
+}
+
+.upload-box:hover {
+  background: #f3f4f6;
+}
+
+.upload-icon {
+  font-size: 40px;
+  color: #fbbf24;
+  margin-bottom: 10px;
+}
+
+.upload-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 4px;
+
+  ion-icon {
+    font-size: 16px;
+    color: #9ca3af;
   }
 }

--- a/src/app/registro-app/registro-app.page.ts
+++ b/src/app/registro-app/registro-app.page.ts
@@ -204,14 +204,42 @@ signedDocumentFile!: File;
   onFileChange(event: Event, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
     const input = event.target as HTMLInputElement;
     if (input.files && input.files.length > 0) {
-      const file = input.files[0];
-      if (tipo === 'identityDocument') {
-        this.identityDocumentFile = file;
-      } else if (tipo === 'certificate') {
-        this.certificateFile = file;
-        } else if (tipo === 'signedDocument') { 
+      this.handleFile(input.files[0], tipo);
+    }
+  }
+
+  onFileDrop(event: DragEvent, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
+    event.preventDefault();
+    if (event.dataTransfer && event.dataTransfer.files.length > 0) {
+      this.handleFile(event.dataTransfer.files[0], tipo);
+      event.dataTransfer.clearData();
+    }
+  }
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  private handleFile(file: File, tipo: 'identityDocument' | 'certificate' | 'signedDocument') {
+    const maxSize = 2 * 1024 * 1024; // 2MB
+    const allowedTypes = ['application/pdf', 'image/png', 'image/jpeg'];
+
+    if (!allowedTypes.includes(file.type)) {
+      this.showToast('Formato inválido. Solo PDF, JPG o PNG.', 'warning');
+      return;
+    }
+
+    if (file.size > maxSize) {
+      this.showToast('El archivo supera el tamaño máximo de 2MB.', 'warning');
+      return;
+    }
+
+    if (tipo === 'identityDocument') {
+      this.identityDocumentFile = file;
+    } else if (tipo === 'certificate') {
+      this.certificateFile = file;
+    } else if (tipo === 'signedDocument') {
       this.signedDocumentFile = file;
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- validate registration uploads for PDF/JPG/PNG and size under 2MB
- add drag-and-drop upload UI with helper messages

## Testing
- `npm test` *(fails: export 'RegistrooService' not found; Can't resolve ionicons.css)*

------
https://chatgpt.com/codex/tasks/task_e_688ec8d113c4832a82b5ca76c1ffebde