### PR TITLE
Update public business card and detail fields

### DIFF
--- a/src/app/components/business-card.component.html
+++ b/src/app/components/business-card.component.html
@@ -1,13 +1,15 @@
 <ion-card class="business-card">
   <ion-card-header>
     <ion-card-title>{{ business.commercialName }}</ion-card-title>
-    <ion-card-subtitle>{{ business.categoryName }}</ion-card-subtitle>
+    <ion-card-subtitle>{{ business.category?.name }}</ion-card-subtitle>
   </ion-card-header>
 
   <ion-card-content>
     <p><strong>Representante:</strong> {{ business.representativeName }}</p>
     <p><strong>RUC:</strong> {{ business.identificationNumber }}</p>
     <p><strong>Teléfono:</strong> {{ business.phone || 'No especificado' }}</p>
+    <p><strong>WhatsApp:</strong> {{ business.whatsappNumber || 'No especificado' }}</p>
+    <p><strong>Dirección:</strong> {{ business.address || 'No especificada' }}</p>
     
     <div class="actions">
       <ion-button fill="clear" size="small" [routerLink]="['/editar-negocio', business.id]">

--- a/src/app/detalle-publico/detalle-publico.page.html
+++ b/src/app/detalle-publico/detalle-publico.page.html
@@ -65,6 +65,18 @@
         <div class="input-display">{{ business.commercialName }}</div>
       </div>
 
+      <!-- Representative -->
+      <div class="form-group" *ngIf="business.representativeName">
+        <label class="form-label">Representante</label>
+        <div class="input-display">{{ business.representativeName }}</div>
+      </div>
+
+      <!-- Identification Number -->
+      <div class="form-group" *ngIf="business.identificationNumber">
+        <label class="form-label">RUC</label>
+        <div class="input-display">{{ business.identificationNumber }}</div>
+      </div>
+
       <!-- Description -->
       <div class="form-group">
         <label class="form-label">Descripción</label>

--- a/src/app/pages/negocios/negocios.page.html
+++ b/src/app/pages/negocios/negocios.page.html
@@ -94,6 +94,28 @@
                 </ion-item>
               </ion-col>
             </ion-row>
+
+            <ion-row>
+              <ion-col size="12">
+                <ion-item lines="none">
+                  <ion-icon slot="start" name="call-outline"></ion-icon>
+                  <ion-label class="ion-text-wrap">
+                    {{ negocio.phone || 'Sin teléfono' }}
+                  </ion-label>
+                </ion-item>
+              </ion-col>
+            </ion-row>
+
+            <ion-row>
+              <ion-col size="12">
+                <ion-item lines="none">
+                  <ion-icon slot="start" name="logo-whatsapp"></ion-icon>
+                  <ion-label class="ion-text-wrap">
+                    {{ negocio.whatsappNumber || 'Sin WhatsApp' }}
+                  </ion-label>
+                </ion-item>
+              </ion-col>
+            </ion-row>
           </ion-grid>
 
           <!-- Botones de acción -->

--- a/src/app/services/detalle-publico.service.ts
+++ b/src/app/services/detalle-publico.service.ts
@@ -31,6 +31,8 @@ export interface Business {
   deliveryService: string;
   salePlace: string;
   category: BusinessCategory;
+  representativeName?: string;
+  identificationNumber?: string;
 }
 
 export interface BusinessResponse {
@@ -105,12 +107,13 @@ export class BusinessService {
 
   // Método para endpoint específico público (respuesta directa)
   getBusinessByIdPublic(id: number): Observable<Business> {
-    const url = `${this.businessUrl}/public/${id}`;
+    const url = `${this.businessUrl}/public-details`;
+    const params = new HttpParams().set('id', id.toString());
     console.log('=== API CALL ===');
     console.log('URL:', url);
     console.log('Business ID:', id);
-    
-    return this.http.get<Business>(url)
+
+    return this.http.get<Business>(url, { params })
       .pipe(
         map(response => {
           console.log('=== API RESPONSE ===');

--- a/src/app/services/negocios.service.ts
+++ b/src/app/services/negocios.service.ts
@@ -24,6 +24,6 @@ export class NegociosService {
       params = params.set('category', categoria);
     }
 
-    return this.http.get<any>(`${this.apiUrl}/business/public/approved?`, { params });
+    return this.http.get<any>(`${this.apiUrl}/business/public/approved`, { params });
   }
 }


### PR DESCRIPTION
## Summary
- Fix approved businesses endpoint and expose additional contact data in public list and cards
- Add representative and RUC fields to public detail view
- Use new `public-details` endpoint for individual business retrieval

## Testing
- `npm run lint` (fails: Prefer using the inject() function over constructor parameter injection)
- `npm test -- --watch=false --browsers=ChromeHeadless` (fails: Karma could not launch due to load error)


------
https://chatgpt.com/codex/tasks/task_e_68a619d1bdd0832bbd801fd01a7b5535