### PR TITLE
feat: update public business card and details

### DIFF
--- a/src/app/detalle-publico/detalle-publico.page.html
+++ b/src/app/detalle-publico/detalle-publico.page.html
@@ -65,6 +65,12 @@
         <div class="input-display">{{ business.commercialName }}</div>
       </div>
 
+      <!-- Representative -->
+      <div class="form-group" *ngIf="business.representativeName">
+        <label class="form-label">Representante</label>
+        <div class="input-display">{{ business.representativeName }}</div>
+      </div>
+
       <!-- Description -->
       <div class="form-group">
         <label class="form-label">Descripción</label>
@@ -185,10 +191,10 @@
         </div>
         
         <div class="info-card">
-          <div class="info-icon">🏷️</div>
+          <div class="info-icon">📞</div>
           <div class="info-content">
-            <h4>Categoría</h4>
-            <p>{{ business.category.name }}</p>
+            <h4>Teléfono</h4>
+            <p>{{ business.phone || 'No especificado' }}</p>
           </div>
         </div>
       </div>

--- a/src/app/pages/negocios/negocios.page.html
+++ b/src/app/pages/negocios/negocios.page.html
@@ -87,9 +87,9 @@
             <ion-row>
               <ion-col size="12">
                 <ion-item lines="none">
-                  <ion-icon slot="start" name="pricetag-outline"></ion-icon>
+                  <ion-icon slot="start" name="call-outline"></ion-icon>
                   <ion-label class="ion-text-wrap">
-                    {{ negocio.category?.name || 'Sin categoría' }}
+                    {{ negocio.phone || 'Teléfono no disponible' }}
                   </ion-label>
                 </ion-item>
               </ion-col>

--- a/src/app/services/detalle-publico.service.ts
+++ b/src/app/services/detalle-publico.service.ts
@@ -13,6 +13,7 @@ export interface BusinessCategory {
 export interface Business {
   id: number;
   commercialName: string;
+  representativeName?: string | null;
   description: string;
   phone: string;
   email: string;
@@ -105,12 +106,13 @@ export class BusinessService {
 
   // Método para endpoint específico público (respuesta directa)
   getBusinessByIdPublic(id: number): Observable<Business> {
-    const url = `${this.businessUrl}/public/${id}`;
+    const url = `${this.businessUrl}/public-details`;
+    const params = new HttpParams().set('id', id.toString());
     console.log('=== API CALL ===');
     console.log('URL:', url);
     console.log('Business ID:', id);
-    
-    return this.http.get<Business>(url)
+
+    return this.http.get<Business>(url, { params })
       .pipe(
         map(response => {
           console.log('=== API RESPONSE ===');


### PR DESCRIPTION
Mostrar el teléfono en lugar de la categoría en las tarjetas de presentación públicas
Mostrar información del representante y del teléfono en la vista de detalles públicos
Utilice el nuevo /business/public-detailspunto final y el campo de representante de soporte