### PR TITLE
feat: improve public business detail view

### DIFF
--- a/src/app/detalle-publico/detalle-publico.page.html
+++ b/src/app/detalle-publico/detalle-publico.page.html
@@ -53,16 +53,27 @@
           </div>
         </div>
 
-        <div class="no-images" *ngIf="!business.photos || business.photos.length === 0">
-          <div class="no-images-icon">📷</div>
-          <p>No hay imágenes disponibles</p>
-        </div>
+      <div class="no-images" *ngIf="!business.photos || business.photos.length === 0">
+        <div class="no-images-icon">📷</div>
+        <p>No hay imágenes disponibles</p>
       </div>
+    </div>
 
-      <!-- Business Name -->
-      <div class="form-group">
-        <label class="form-label">Nombre del Negocio</label>
-        <div class="input-display">{{ business.commercialName }}</div>
+    <!-- Business Logo -->
+    <div class="logo-container" *ngIf="business.logoUrl">
+      <img [src]="business.logoUrl" [alt]="business.commercialName" class="business-logo" />
+    </div>
+
+    <!-- Business Name -->
+    <div class="form-group">
+      <label class="form-label">Nombre del Negocio</label>
+      <div class="input-display">{{ business.commercialName }}</div>
+    </div>
+
+      <!-- Representative -->
+      <div class="form-group" *ngIf="business.representativeName">
+        <label class="form-label">Representante</label>
+        <div class="input-display">{{ business.representativeName }}</div>
       </div>
 
       <!-- Description -->
@@ -185,10 +196,10 @@
         </div>
         
         <div class="info-card">
-          <div class="info-icon">🏷️</div>
+          <div class="info-icon">📞</div>
           <div class="info-content">
-            <h4>Categoría</h4>
-            <p>{{ business.category.name }}</p>
+            <h4>Teléfono</h4>
+            <p>{{ business.phone || 'No especificado' }}</p>
           </div>
         </div>
       </div>

--- a/src/app/detalle-publico/detalle-publico.page.scss
+++ b/src/app/detalle-publico/detalle-publico.page.scss
@@ -132,6 +132,17 @@
   padding: 30px;
 }
 
+.logo-container {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.business-logo {
+  max-width: 150px;
+  height: auto;
+  border-radius: 8px;
+}
+
 /* Carousel */
 .carousel-container {
   margin-bottom: 30px;

--- a/src/app/detalle-publico/detalle-publico.page.ts
+++ b/src/app/detalle-publico/detalle-publico.page.ts
@@ -13,7 +13,7 @@ import { IonicModule } from '@ionic/angular';
 })
 export class DetallePublicoPage implements OnInit {
   @Input() businessId?: number;
-  @Input() showModal: boolean = false;
+  @Input() showModal: boolean = true;
   
   business: Business | null = null;
   currentImageIndex: number = 0;
@@ -115,6 +115,7 @@ export class DetallePublicoPage implements OnInit {
 
   closeModal(): void {
     this.showModal = false;
+    window.history.back();
   }
 
   saveDetails(): void {

--- a/src/app/pages/negocios/negocios.page.html
+++ b/src/app/pages/negocios/negocios.page.html
@@ -87,9 +87,9 @@
             <ion-row>
               <ion-col size="12">
                 <ion-item lines="none">
-                  <ion-icon slot="start" name="pricetag-outline"></ion-icon>
+                  <ion-icon slot="start" name="call-outline"></ion-icon>
                   <ion-label class="ion-text-wrap">
-                    {{ negocio.category?.name || 'Sin categoría' }}
+                    {{ negocio.phone || 'Teléfono no disponible' }}
                   </ion-label>
                 </ion-item>
               </ion-col>
@@ -98,7 +98,7 @@
 
           <!-- Botones de acción -->
            <div class="action-buttons">
-            <ion-button expand="block" fill="outline" size="small" (click)="verDetalles(negocio)">
+            <ion-button expand="block" fill="outline" size="small" (click)="openBusiness(negocio); $event.stopPropagation()">
               <ion-icon slot="start" name="eye-outline"></ion-icon>
               Ver Detalles
             </ion-button>

--- a/src/app/pages/negocios/negocios.page.ts
+++ b/src/app/pages/negocios/negocios.page.ts
@@ -80,14 +80,7 @@ export class NegociosPage implements OnInit {
       });
   }
   openBusiness(negocio: any) {
-    // Aquí defines qué pasa al hacer click en un negocio
-    // Por ejemplo, navegar a detalle o mostrar un modal
-    console.log('Negocio seleccionado:', negocio);
-
-    // Ejemplo: si tienes router, puedes navegar a una página de detalle pasando id
-    // this.router.navigate(['/detalle-negocio', negocio.id]);
-
-    // O abrir un modal, etc.
+    this.router.navigate(['/detalle-publico', negocio.id]);
   }
 
   paginaAnterior() {
@@ -101,8 +94,4 @@ export class NegociosPage implements OnInit {
       this.cargarNegocios(this.paginaActual + 1);
     }
   }
- verDetalles(negocio: any) {
-  // Navegar a la página de detalles con el ID del negocio
-  this.router.navigate(['/detalle-publico', negocio.id]);
-}
 }

--- a/src/app/services/detalle-publico.service.ts
+++ b/src/app/services/detalle-publico.service.ts
@@ -13,6 +13,7 @@ export interface BusinessCategory {
 export interface Business {
   id: number;
   commercialName: string;
+  representativeName?: string | null;
   description: string;
   phone: string;
   email: string;
@@ -105,12 +106,13 @@ export class BusinessService {
 
   // Método para endpoint específico público (respuesta directa)
   getBusinessByIdPublic(id: number): Observable<Business> {
-    const url = `${this.businessUrl}/public/${id}`;
+    const url = `${this.businessUrl}/public-details`;
+    const params = new HttpParams().set('id', id.toString());
     console.log('=== API CALL ===');
     console.log('URL:', url);
     console.log('Business ID:', id);
-    
-    return this.http.get<Business>(url)
+
+    return this.http.get<Business>(url, { params })
       .pipe(
         map(response => {
           console.log('=== API RESPONSE ===');


### PR DESCRIPTION
## Summary
- Navigate to public detail view from business cards
- Display business logo and ensure modal closes back to list

## Testing
- `npm run lint` (fails: @angular-eslint/prefer-inject)
- `npx ng test --watch=false --progress=false` (fails: DetallePublicoService not found; missing ionicons CSS)


------
https://chatgpt.com/codex/tasks/task_e_68a621114b84832b8c0fa7e3a2655c3b